### PR TITLE
Add unknown type

### DIFF
--- a/generate-test-data.js
+++ b/generate-test-data.js
@@ -15,7 +15,7 @@ const brands = [
 ];
 
 const formFactors = [
-  'Phone', 'Tablet', 'TV', 'Android Automotive', 'Chromebook', 'Wearable', 'Google Play Games on PC'
+  'Phone', 'Tablet', 'TV', 'Android Automotive', 'Chromebook', 'Wearable', 'Google Play Games on PC', 'Unknown'
 ];
 
 const processors = [

--- a/src/components/DeviceCard.tsx
+++ b/src/components/DeviceCard.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { AndroidDevice } from "@/types/device";
 import { formatRam } from "@/lib/deviceUtils";
 import { getDeviceColors, getDeviceCategoryLabel, parseRamMB, ColorMode } from "@/lib/deviceColors";
-import { DeviceMobile, DeviceTablet, Television, Car, Laptop, Watch, GameController, Plus, Minus, Code } from "@phosphor-icons/react";
+import { DeviceMobile, DeviceTablet, Television, Car, Laptop, Watch, GameController, Plus, Minus, Code, Question } from "@phosphor-icons/react";
 import { useComparison } from "@/contexts/ComparisonContext";
 
 interface DeviceCardProps {
@@ -44,7 +44,7 @@ export const DeviceCard = ({ device, onClick, onShowJson, colorMode = 'formFacto
       case 'google play games on pc':
         return <GameController className={iconClass} style={iconStyle} />;
       case 'unknown':
-        return <span className={iconClass} style={{ ...iconStyle, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 'bold', fontSize: size === 'lg' ? '1.5rem' : '0.875rem' }}>?</span>;
+        return <Question className={iconClass} style={iconStyle} />;
       default:
         return <DeviceMobile className={iconClass} style={iconStyle} />;
     }

--- a/src/components/DeviceCard.tsx
+++ b/src/components/DeviceCard.tsx
@@ -43,6 +43,8 @@ export const DeviceCard = ({ device, onClick, onShowJson, colorMode = 'formFacto
         return <Watch className={iconClass} style={iconStyle} />;
       case 'google play games on pc':
         return <GameController className={iconClass} style={iconStyle} />;
+      case 'unknown':
+        return <span className={iconClass} style={{ ...iconStyle, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 'bold', fontSize: size === 'lg' ? '1.5rem' : '0.875rem' }}>?</span>;
       default:
         return <DeviceMobile className={iconClass} style={iconStyle} />;
     }

--- a/src/components/DeviceComparisonModal.tsx
+++ b/src/components/DeviceComparisonModal.tsx
@@ -33,6 +33,8 @@ export const DeviceComparisonModal = ({ open, onOpenChange }: DeviceComparisonMo
         return <Watch className="h-4 w-4" />;
       case 'google play games on pc':
         return <GameController className="h-4 w-4" />;
+      case 'unknown':
+        return <span className="h-4 w-4 flex items-center justify-center font-bold text-sm">?</span>;
       default:
         return <DeviceMobile className="h-4 w-4" />;
     }

--- a/src/components/DeviceComparisonModal.tsx
+++ b/src/components/DeviceComparisonModal.tsx
@@ -6,7 +6,7 @@ import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { AndroidDevice } from "@/types/device";
 import { formatRam } from "@/lib/deviceUtils";
-import { DeviceMobile, DeviceTablet, Television, Car, Laptop, Watch, GameController, X } from "@phosphor-icons/react";
+import { DeviceMobile, DeviceTablet, Television, Car, Laptop, Watch, GameController, X, Question } from "@phosphor-icons/react";
 import { useComparison } from "@/contexts/ComparisonContext";
 
 interface DeviceComparisonModalProps {
@@ -34,7 +34,7 @@ export const DeviceComparisonModal = ({ open, onOpenChange }: DeviceComparisonMo
       case 'google play games on pc':
         return <GameController className="h-4 w-4" />;
       case 'unknown':
-        return <span className="h-4 w-4 flex items-center justify-center font-bold text-sm">?</span>;
+        return <Question className="h-4 w-4" />;
       default:
         return <DeviceMobile className="h-4 w-4" />;
     }

--- a/src/components/DeviceDetailModal.tsx
+++ b/src/components/DeviceDetailModal.tsx
@@ -44,6 +44,8 @@ export const DeviceDetailModal = ({ device, open, onOpenChange }: DeviceDetailMo
         return <Watch className="h-5 w-5" />;
       case 'google play games on pc':
         return <GameController className="h-5 w-5" />;
+      case 'unknown':
+        return <span className="h-5 w-5 flex items-center justify-center font-bold text-lg">?</span>;
       default:
         return <DeviceMobile className="h-5 w-5" />;
     }

--- a/src/components/DeviceDetailModal.tsx
+++ b/src/components/DeviceDetailModal.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AndroidDevice } from "@/types/device";
 import { formatRam } from "@/lib/deviceUtils";
-import { DeviceMobile, Monitor, DeviceTablet, Television, Car, Laptop, Watch, GameController, Cpu, Desktop, Code } from "@phosphor-icons/react";
+import { DeviceMobile, Monitor, DeviceTablet, Television, Car, Laptop, Watch, GameController, Cpu, Desktop, Code, Question } from "@phosphor-icons/react";
 import { DeviceJsonModal } from "./DeviceJsonModal";
 import { useState } from "react";
 import GoogleLogoSVG from "@/assets/images/google_G_logo.svg";
@@ -45,7 +45,7 @@ export const DeviceDetailModal = ({ device, open, onOpenChange }: DeviceDetailMo
       case 'google play games on pc':
         return <GameController className="h-5 w-5" />;
       case 'unknown':
-        return <span className="h-5 w-5 flex items-center justify-center font-bold text-lg">?</span>;
+        return <Question className="h-5 w-5" />;
       default:
         return <DeviceMobile className="h-5 w-5" />;
     }

--- a/src/lib/deviceColors.ts
+++ b/src/lib/deviceColors.ts
@@ -75,6 +75,14 @@ export const FORM_FACTOR_COLORS: Record<string, DeviceColorScheme> = {
     border: 'oklch(0.85 0.06 340)',
     text: 'oklch(0.25 0.18 340)',
     icon: 'oklch(0.35 0.20 340)'
+  },
+  'Unknown': {
+    primary: 'oklch(0.65 0.08 0)', // Grey - lighter and less saturated
+    secondary: 'oklch(0.92 0.04 0)',
+    background: 'oklch(0.98 0.01 0)',
+    border: 'oklch(0.85 0.06 0)',
+    text: 'oklch(0.25 0.18 0)',
+    icon: 'oklch(0.35 0.20 0)'
   }
 };
 

--- a/src/lib/deviceValidation.ts
+++ b/src/lib/deviceValidation.ts
@@ -20,10 +20,11 @@ const AndroidDeviceSchema = z.object({
     'Android Automotive', 
     'Chromebook', 
     'Wearable', 
-    'Google Play Games on PC'
+    'Google Play Games on PC',
+    'Unknown'
   ], {
     errorMap: () => ({ 
-      message: 'Form factor must be one of: Phone, TV, Tablet, Android Automotive, Chromebook, Wearable, Google Play Games on PC' 
+      message: 'Form factor must be one of: Phone, TV, Tablet, Android Automotive, Chromebook, Wearable, Google Play Games on PC, Unknown' 
     })
   }),
   processorName: z.string().min(1, 'Processor name is required'),

--- a/src/lib/testDataGenerator.ts
+++ b/src/lib/testDataGenerator.ts
@@ -15,7 +15,7 @@ const brands = [
 ];
 
 const formFactors = [
-  'Phone', 'Tablet', 'TV', 'Android Automotive', 'Chromebook', 'Wearable', 'Google Play Games on PC'
+  'Phone', 'Tablet', 'TV', 'Android Automotive', 'Chromebook', 'Wearable', 'Google Play Games on PC', 'Unknown'
 ];
 
 const processors = [


### PR DESCRIPTION
This pull request adds support for a new "Unknown" form factor across the application. The changes ensure that devices with an unknown form factor are properly handled, displayed with a dedicated icon, and validated throughout the codebase.

**Support for "Unknown" Form Factor:**

* Added "Unknown" to the list of supported form factors in device data generation scripts (`generate-test-data.js`, `src/lib/testDataGenerator.ts`) and device validation schema (`src/lib/deviceValidation.ts`). [[1]](diffhunk://#diff-ec917fd13619b0515ae567f405960d492a43c4b9f7837e5b5158537028274206L18-R18) [[2]](diffhunk://#diff-842c85f857644da2b7207b959d1e1e17d3067e4bd2321121e50c9b2a99793e1dL18-R18) [[3]](diffhunk://#diff-f3b0e5f1b0db1c010f7acc40bfbdf63940fcee75eccf6daa2627bd6a389a9c6dL23-R27)
* Updated the error message in the validation schema to include "Unknown" as a valid form factor.

**UI and Icon Updates:**

* Introduced the `Question` icon from `@phosphor-icons/react` and updated all relevant components (`DeviceCard`, `DeviceDetailModal`, `DeviceComparisonModal`) to display this icon for devices with the "Unknown" form factor. [[1]](diffhunk://#diff-200ada05e0da1e07f43654e3a56cb405f5b2dd1ebc00db80457b47853d269a72L7-R7) [[2]](diffhunk://#diff-200ada05e0da1e07f43654e3a56cb405f5b2dd1ebc00db80457b47853d269a72R46-R47) [[3]](diffhunk://#diff-1dc0125803f1e0b89e37ea8c958500fdbc257de9676c39725650dbcd607312c9L8-R8) [[4]](diffhunk://#diff-1dc0125803f1e0b89e37ea8c958500fdbc257de9676c39725650dbcd607312c9R47-R48) [[5]](diffhunk://#diff-ba61737c2edbf938a30c9643f6355349d6b996fb611bde86ba3b17058cbe38b4L9-R9) [[6]](diffhunk://#diff-ba61737c2edbf938a30c9643f6355349d6b996fb611bde86ba3b17058cbe38b4R36-R37)
* Added a new color scheme for the "Unknown" form factor in `FORM_FACTOR_COLORS` to ensure visual consistency.