### PR TITLE
Fixes

### DIFF
--- a/src/components/DeviceFiltersPanel.tsx
+++ b/src/components/DeviceFiltersPanel.tsx
@@ -116,6 +116,7 @@ export const DeviceFiltersPanel = ({
           selectedManufacturers={filters.manufacturers || []}
           onSelectionChange={(selected) => updateFilter('manufacturers', selected)}
           placeholder="All Manufacturers"
+          maxDisplayedItems={1}
         />
 
         <Select value={filters.minRam} onValueChange={(value) => updateFilter('minRam', value)}>

--- a/src/components/DeviceFiltersPanel.tsx
+++ b/src/components/DeviceFiltersPanel.tsx
@@ -120,7 +120,7 @@ export const DeviceFiltersPanel = ({
         />
 
         <Select value={filters.minRam} onValueChange={(value) => updateFilter('minRam', value)}>
-          <SelectTrigger className="w-[140px]">
+          <SelectTrigger className="w-[120px]">
             <SelectValue placeholder="Min RAM" />
           </SelectTrigger>
           <SelectContent>
@@ -135,7 +135,7 @@ export const DeviceFiltersPanel = ({
         </Select>
 
         <Select value={filters.sdkVersion} onValueChange={(value) => updateFilter('sdkVersion', value)}>
-          <SelectTrigger className="w-[140px]">
+          <SelectTrigger className="w-[120px]">
             <SelectValue placeholder="SDK Version" />
           </SelectTrigger>
           <SelectContent>
@@ -173,10 +173,10 @@ export const DeviceFiltersPanel = ({
 
         {hasActiveFilters && (
           <Button
-            variant="outline"
+            variant="destructive"
             size="sm"
             onClick={clearFilters}
-            className="flex items-center gap-2"
+            className="flex items-center gap-2 bg-destructive hover:bg-destructive/90 text-destructive-foreground"
           >
             <X className="h-4 w-4" />
             Clear Filters

--- a/src/components/DeviceFiltersPanel.tsx
+++ b/src/components/DeviceFiltersPanel.tsx
@@ -176,7 +176,7 @@ export const DeviceFiltersPanel = ({
             variant="destructive"
             size="sm"
             onClick={clearFilters}
-            className="flex items-center gap-2 bg-destructive hover:bg-destructive/90 text-destructive-foreground"
+            className="flex items-center gap-2 bg-destructive hover:bg-destructive/90 text-destructive-foreground border border-destructive"
           >
             <X className="h-4 w-4" />
             Clear Filters

--- a/src/components/SearchableMultiSelectManufacturer.tsx
+++ b/src/components/SearchableMultiSelectManufacturer.tsx
@@ -111,7 +111,7 @@ export const SearchableMultiSelectManufacturer = ({
                   key={manufacturer}
                   value={manufacturer}
                   onSelect={() => handleSelect(manufacturer)}
-                  className="cursor-pointer"
+                  className="cursor-pointer group"
                 >
                   <Check
                     className={cn(
@@ -121,7 +121,7 @@ export const SearchableMultiSelectManufacturer = ({
                   />
                   {manufacturer}
                   {selectedManufacturers.includes(manufacturer) && (
-                    <Badge variant="outline" className="ml-auto text-xs">
+                    <Badge variant="outline" className="ml-auto text-xs group-hover:text-primary-foreground group-hover:border-primary-foreground/50">
                       Selected
                     </Badge>
                   )}

--- a/src/components/SearchableMultiSelectManufacturer.tsx
+++ b/src/components/SearchableMultiSelectManufacturer.tsx
@@ -115,7 +115,7 @@ export const SearchableMultiSelectManufacturer = ({
                 >
                   <Check
                     className={cn(
-                      "mr-2 h-4 w-4",
+                      "mr-2 h-4 w-4 text-primary",
                       selectedManufacturers.includes(manufacturer) ? "opacity-100" : "opacity-0"
                     )}
                   />


### PR DESCRIPTION
This pull request updates the device filtering UI to improve usability and visual feedback. The main changes include adjustments to filter dropdown sizing, enhanced styling for selected manufacturers, and a more prominent "Clear Filters" button.

**UI/UX improvements to device filters:**

* Reduced the width of the `SelectTrigger` components for both RAM and SDK Version filters from `140px` to `120px` to better fit the UI. [[1]](diffhunk://#diff-3ff8defae2288b6a3693b736a924440be6e79ee3c4e8be1446fa5b4711c8dc5dR119-R123) [[2]](diffhunk://#diff-3ff8defae2288b6a3693b736a924440be6e79ee3c4e8be1446fa5b4711c8dc5dL137-R138)
* Limited the number of displayed manufacturer items in the filter dropdown to 1 for a cleaner appearance (`maxDisplayedItems={1}`).

**Visual feedback enhancements:**

* Updated the "Clear Filters" button to use the `destructive` variant with additional styling, making it more visually distinct and easier to identify.
* Improved the manufacturer selection UI: added a `group` class for hover effects, set the checkmark icon to use the `text-primary` color, and updated the "Selected" badge to change color and border on hover for better feedback.