### PR TITLE
feat: Add unit test coverage for key components

### DIFF
--- a/src/components/DeviceFiltersPanel.test.tsx
+++ b/src/components/DeviceFiltersPanel.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DeviceFiltersPanel } from './DeviceFiltersPanel';
+import { DeviceFilters } from '@/types/device';
+
+const mockFilters: DeviceFilters = {
+  search: '',
+  formFactor: 'all',
+  manufacturer: 'all',
+  manufacturers: [],
+  minRam: 'all',
+  sdkVersion: 'all',
+  ramRange: [0, 32],
+  sdkVersionRange: [1, 34],
+};
+
+const placeholderText = "Search devices, manufacturers, processors...";
+
+describe('DeviceFiltersPanel', () => {
+  it('should render all filter controls', () => {
+    render(
+      <DeviceFiltersPanel
+        filters={mockFilters}
+        onFiltersChange={vi.fn()}
+        manufacturers={['Samsung', 'Google']}
+        formFactors={['Phone', 'Tablet']}
+        sdkVersions={['13', '14']}
+        deviceCount={10}
+        totalDevices={100}
+        ramRange={[0, 32]}
+        sdkVersionRange={[1, 34]}
+        isFiltering={false}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(placeholderText)).toBeInTheDocument();
+    expect(screen.getByText('All Form Factors')).toBeInTheDocument();
+    expect(screen.getByText('All Manufacturers')).toBeInTheDocument();
+  });
+
+  it('should call onFiltersChange when search input changes', () => {
+    const onFiltersChange = vi.fn();
+    render(
+        <DeviceFiltersPanel
+            filters={mockFilters}
+            onFiltersChange={onFiltersChange}
+            manufacturers={[]}
+            formFactors={[]}
+            sdkVersions={[]}
+            deviceCount={0}
+            totalDevices={0}
+            ramRange={[0, 32]}
+            sdkVersionRange={[1, 34]}
+            isFiltering={false}
+        />
+    );
+
+    const searchInput = screen.getByPlaceholderText(placeholderText);
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ search: 'test' }));
+  });
+});

--- a/src/components/ui/select.test.tsx
+++ b/src/components/ui/select.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from './select';
+
+describe('Select', () => {
+  it('should render with a placeholder', () => {
+    render(
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Select a fruit" />
+        </SelectTrigger>
+      </Select>
+    );
+    expect(screen.getByText('Select a fruit')).toBeInTheDocument();
+  });
+
+  it('should open the select menu on trigger click', async () => {
+    render(
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Select a fruit" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="apple">Apple</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+    fireEvent.click(screen.getByText('Select a fruit'));
+    expect(await screen.findByText('Apple')).toBeInTheDocument();
+  });
+
+  it('should call onValueChange when an item is selected', async () => {
+    const onValueChange = vi.fn();
+    render(
+      <Select onValueChange={onValueChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select a fruit" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="apple">Apple</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+    fireEvent.click(screen.getByText('Select a fruit'));
+    const appleOption = await screen.findByText('Apple');
+    fireEvent.click(appleOption);
+
+    expect(onValueChange).toHaveBeenCalledWith('apple');
+  });
+
+  it('should display the selected value', async () => {
+    render(
+      <Select defaultValue="apple">
+        <SelectTrigger>
+          <SelectValue placeholder="Select a fruit" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="apple">Apple</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useCatalogLoader.test.ts
+++ b/src/hooks/useCatalogLoader.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCatalogLoader } from './useCatalogLoader';
+import { DeviceCatalogService } from '@/services/deviceCatalogService';
+import { useKV } from '@/hooks/useKV';
+
+// Mock DeviceCatalogService
+vi.mock('@/services/deviceCatalogService', () => ({
+  DeviceCatalogService: {
+    loadFromGitHub: vi.fn(),
+  },
+}));
+
+// Mock useKV
+vi.mock('@/hooks/useKV', () => ({
+  useKV: vi.fn(),
+}));
+
+describe('useCatalogLoader', () => {
+  let mockSetCatalogDevices: vi.Mock;
+  let mockSetHasAttemptedLoad: vi.Mock;
+  let mockCatalogDevices: any[] = [];
+  let mockHasAttemptedLoad = false;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSetCatalogDevices = vi.fn((updater) => {
+      mockCatalogDevices = typeof updater === 'function' ? updater(mockCatalogDevices) : updater;
+    });
+    mockSetHasAttemptedLoad = vi.fn((updater) => {
+      mockHasAttemptedLoad = typeof updater === 'function' ? updater(mockHasAttemptedLoad) : updater;
+    });
+
+    (useKV as vi.Mock).mockImplementation((key: string, initialValue: any) => {
+      if (key === 'catalog-devices') {
+        mockCatalogDevices = []; // Start with empty catalog
+        return [mockCatalogDevices, mockSetCatalogDevices];
+      }
+      if (key === 'catalog-load-attempted') {
+        mockHasAttemptedLoad = false; // Start with no load attempt
+        return [mockHasAttemptedLoad, mockSetHasAttemptedLoad];
+      }
+      if (key === 'uploaded-devices') {
+        return [[], vi.fn()];
+      }
+      return [initialValue, vi.fn()];
+    });
+
+    (DeviceCatalogService.loadFromGitHub as vi.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should successfully load the catalog on mount', async () => {
+    const mockDevices = [{ name: 'Test Device' }];
+    (DeviceCatalogService.loadFromGitHub as vi.Mock).mockResolvedValue(mockDevices);
+
+    const { result } = renderHook(() => useCatalogLoader());
+
+    expect(result.current.loadingState.isLoading).toBe(false);
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(result.current.loadingState.isLoading).toBe(false);
+    expect(mockSetCatalogDevices).toHaveBeenCalledWith(mockDevices);
+    expect(mockSetHasAttemptedLoad).toHaveBeenCalledWith(true);
+  });
+
+  it('should handle errors during catalog load on mount', async () => {
+    const error = new Error('Failed to load');
+    (DeviceCatalogService.loadFromGitHub as vi.Mock).mockRejectedValue(error);
+
+    const { result } = renderHook(() => useCatalogLoader());
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(result.current.loadingState.isLoading).toBe(false);
+    expect(mockSetCatalogDevices).not.toHaveBeenCalled();
+    expect(mockSetHasAttemptedLoad).toHaveBeenCalledWith(true);
+  });
+
+  it('should retry loading the catalog', async () => {
+    (DeviceCatalogService.loadFromGitHub as vi.Mock).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useCatalogLoader());
+
+    await act(async () => {
+        result.current.retryLoad();
+    });
+
+    expect(DeviceCatalogService.loadFromGitHub).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip loading the catalog', async () => {
+    const { result } = renderHook(() => useCatalogLoader());
+
+    await act(async () => {
+      result.current.skipLoad();
+    });
+
+    expect(result.current.loadingState.isLoading).toBe(false);
+    expect(mockSetHasAttemptedLoad).toHaveBeenCalledWith(true);
+  });
+
+  it('should clear the catalog', async () => {
+    const { result } = renderHook(() => useCatalogLoader());
+
+    await act(async () => {
+      result.current.clearCatalog();
+    });
+
+    expect(mockSetCatalogDevices).toHaveBeenCalledWith([]);
+    expect(mockSetHasAttemptedLoad).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/hooks/useCatalogLoader.ts
+++ b/src/hooks/useCatalogLoader.ts
@@ -64,6 +64,13 @@ export function useCatalogLoader(): CatalogLoadingHook {
     } catch {
       // Error is already handled in the service and reflected in loadingState
       setHasAttemptedLoad(true);
+
+      // Also ensure loading is stopped on error
+      setLoadingState(prev => ({
+        ...prev,
+        isLoading: false
+      }));
+
       setTimeout(() => {
         setIsInitialLoad(false);
       }, 100);

--- a/src/services/deviceCatalogService.test.ts
+++ b/src/services/deviceCatalogService.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DeviceCatalogService } from './deviceCatalogService';
+import { sanitizeDeviceData } from '@/lib/deviceValidation';
+
+// Mock the sanitizeDeviceData function
+vi.mock('@/lib/deviceValidation', () => ({
+  sanitizeDeviceData: vi.fn(data => data),
+}));
+
+const mockFetch = (data: any, ok = true, status = 200) => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Not Found',
+    json: async () => data,
+  } as Response);
+};
+
+const mockFetchError = (error: Error) => {
+  global.fetch = vi.fn().mockRejectedValue(error);
+};
+
+describe('DeviceCatalogService', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  describe('loadFromGitHub', () => {
+    it('should load, sanitize, and return device data successfully', async () => {
+      const mockDevices = [{ name: 'Test Device' }];
+      mockFetch(mockDevices);
+
+      const onProgress = vi.fn();
+      const result = await DeviceCatalogService.loadFromGitHub(onProgress);
+
+      expect(result).toEqual(mockDevices);
+      expect(sanitizeDeviceData).toHaveBeenCalledWith(mockDevices);
+      expect(onProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ progress: 100, message: 'Loaded 1 devices successfully' })
+      );
+    });
+
+    it('should throw an error if the network response is not ok', async () => {
+      mockFetch(null, false, 404);
+      const onProgress = vi.fn();
+
+      await expect(DeviceCatalogService.loadFromGitHub(onProgress)).rejects.toThrow('HTTP 404: Not Found');
+      expect(onProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'HTTP 404: Not Found' })
+      );
+    });
+
+    it('should throw an error if the fetched data is not an array', async () => {
+      mockFetch({});
+      const onProgress = vi.fn();
+
+      await expect(DeviceCatalogService.loadFromGitHub(onProgress)).rejects.toThrow('No devices found in catalog');
+      expect(onProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'No devices found in catalog' })
+      );
+    });
+
+    it('should throw an error if fetching fails', async () => {
+      const error = new Error('Network error');
+      mockFetchError(error);
+      const onProgress = vi.fn();
+
+      await expect(DeviceCatalogService.loadFromGitHub(onProgress)).rejects.toThrow('Network error');
+      expect(onProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Network error' })
+      );
+    });
+
+    it('should call onProgress with correct states', async () => {
+        const mockDevices = [{ name: 'Test Device' }];
+        mockFetch(mockDevices);
+        const onProgress = vi.fn();
+
+        await DeviceCatalogService.loadFromGitHub(onProgress);
+
+        expect(onProgress).toHaveBeenCalledWith({ isLoading: true, progress: 10, message: 'Connecting to device catalog...', error: null });
+        expect(onProgress).toHaveBeenCalledWith({ isLoading: true, progress: 30, message: 'Downloading device data...', error: null });
+        expect(onProgress).toHaveBeenCalledWith({ isLoading: true, progress: 60, message: 'Processing device catalog...', error: null });
+        expect(onProgress).toHaveBeenCalledWith({ isLoading: true, progress: 80, message: 'Validating device data...', error: null });
+        expect(onProgress).toHaveBeenCalledWith({ isLoading: true, progress: 90, message: 'Finalizing catalog...', error: null });
+        expect(onProgress).toHaveBeenCalledWith({ isLoading: false, progress: 100, message: 'Loaded 1 devices successfully', error: null });
+      });
+  });
+
+  describe('checkCatalogAvailability', () => {
+    it('should return true if the catalog is available', async () => {
+        mockFetch(null, true);
+        const isAvailable = await DeviceCatalogService.checkCatalogAvailability();
+        expect(isAvailable).toBe(true);
+    });
+
+    it('should return false if the catalog is not available', async () => {
+        mockFetch(null, false);
+        const isAvailable = await DeviceCatalogService.checkCatalogAvailability();
+        expect(isAvailable).toBe(false);
+    });
+
+    it('should return false if fetch throws an error', async () => {
+        mockFetchError(new Error('Network error'));
+        const isAvailable = await DeviceCatalogService.checkCatalogAvailability();
+        expect(isAvailable).toBe(false);
+    });
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -64,3 +64,6 @@ Object.defineProperty(window, 'scrollTo', {
   writable: true,
   value: vi.fn(),
 });
+
+// Mock scrollIntoView for Radix UI components
+Element.prototype.scrollIntoView = vi.fn();


### PR DESCRIPTION
Adds unit tests for the following components and hooks:
- DeviceCatalogService
- useCatalogLoader hook
- DeviceFiltersPanel component
- Select UI component

Also includes a bug fix in the useCatalogLoader hook to correctly handle loading state on error, and updates the test setup to mock scrollIntoView for Radix UI components.